### PR TITLE
Add vite-plugin-singlefile for single-file builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 node_modules
 .trash
+dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "tailwindcss": "^4.1.1",
         "typescript": "^5.3.3",
         "vite": "^6.2.5",
+        "vite-plugin-singlefile": "^2.2.0",
         "vite-plugin-svgr": "^4.3.0"
       }
     },
@@ -9962,6 +9963,22 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-singlefile": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-singlefile/-/vite-plugin-singlefile-2.2.0.tgz",
+      "integrity": "sha512-Ik1wXmJaGzeQtUeIV7JprDUqqy6DlLzXAY27Blei5peE4c9VJF+Kp9xWDJeuX0RJUZmFbIAuw1/RAh06A+Ql7w==",
+      "dev": true,
+      "dependencies": {
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">18.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^4.35.0",
+        "vite": "^5.4.11 || ^6.0.0"
       }
     },
     "node_modules/vite-plugin-svgr": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "tailwindcss": "^4.1.1",
     "typescript": "^5.3.3",
     "vite": "^6.2.5",
+    "vite-plugin-singlefile": "^2.2.0",
     "vite-plugin-svgr": "^4.3.0"
   },
   "resolutions": {

--- a/src/eventSourceManager.jsx
+++ b/src/eventSourceManager.jsx
@@ -1,4 +1,5 @@
 import useEventStore from "./hooks/useEventStore.js";
+import {EventSourcePolyfill} from 'event-source-polyfill';
 
 let currentEventSource = null;
 const isEqual = (a, b) => JSON.stringify(a) === JSON.stringify(b);
@@ -62,7 +63,7 @@ export const createEventSource = (url, token) => {
         flushTimeout = null;
     };
 
-    let cachedUrl = "/sse?cache=true&token=" + token;
+    let cachedUrl = "/node/name/localhost/daemon/event?cache=true";
     const filters = [
         "NodeStatusUpdated",
         "NodeMonitorUpdated",
@@ -74,7 +75,12 @@ export const createEventSource = (url, token) => {
     ];
     filters.forEach((f) => cachedUrl += `&filter=${f}`);
 
-    currentEventSource = new EventSource(cachedUrl);
+    currentEventSource = new EventSourcePolyfill(cachedUrl, {
+        headers: {
+            "Authorization": 'Bearer ' + token,
+            "Content-Type": "text/event-stream",
+        }
+    });
 
     currentEventSource.onopen = () => {
         console.log("✅ SSE connection established!");

--- a/src/hooks/useFetchDaemonStatus.jsx
+++ b/src/hooks/useFetchDaemonStatus.jsx
@@ -50,7 +50,7 @@ const useFetchDaemonStatus = () => {
         }
 
         // Create new SSE connection
-        eventSourceRef.current = createEventSource("/sse", token);
+        eventSourceRef.current = createEventSource("/node/name/localhost/daemon/event", token);
     };
 
     return { daemon, nodes, clusterStats, error, loading, fetchNodes: refreshDaemonStatus, startEventReception };

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,11 +1,13 @@
-import { defineConfig } from 'vite';
+import {defineConfig} from 'vite';
 import react from '@vitejs/plugin-react';
+import {viteSingleFile} from "vite-plugin-singlefile"
 import tailwindcss from '@tailwindcss/vite';
+
 
 const baseUrl = process.env.BASE_URL || 'https://localhost:1215/';
 
 export default defineConfig({
-    plugins: [react(), tailwindcss()],
+    plugins: [react(), tailwindcss(), viteSingleFile()],
     server: {
         proxy: {
             '/auth/info': {
@@ -68,4 +70,9 @@ export default defineConfig({
             },
         },
     },
+    "build": {
+        assetsInlineLimit: Infinity, // ensure all assets are inlined
+        cssCodeSplit: false,         // don't split CSS
+        target: 'esnext',
+    }
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -40,33 +40,10 @@ export default defineConfig({
                 changeOrigin: true,
                 secure: false,
             },
-            '/sse': {
+            '/node/name/localhost/daemon/event': {
                 target: baseUrl,
                 changeOrigin: true,
                 secure: false,
-                rewrite: (path) => path.replace(/^\/sse/, '/node/name/localhost/daemon/event'), // Réécriture comme dans setupProxy
-                configure: (proxy, options) => {
-                    proxy.on('proxyReq', (proxyReq, req) => {
-                        console.log('🔄 Proxy: Sending SSE request to backend...');
-                        const urlParams = new URLSearchParams(req.url.split('?')[1]);
-                        const authToken = urlParams.get('token');
-                        console.log('authToken:', authToken);
-                        if (authToken) {
-                            proxyReq.setHeader('Authorization', `Bearer ${authToken}`);
-                        } else {
-                            console.error('❌ No authentication token found!');
-                        }
-                        proxyReq.setHeader('Content-Type', 'text/event-stream');
-                    });
-
-                    proxy.on('proxyRes', (proxyRes) => {
-                        console.log('📥 Proxy: Received SSE response:', proxyRes.statusCode);
-                    });
-
-                    proxy.on('error', (err) => {
-                        console.error('❌ Proxy Error:', err);
-                    });
-                },
             },
         },
     },


### PR DESCRIPTION
Integrated vite-plugin-singlefile to streamline bundling into a single file during the build process. Updated related configuration in `vite.config.js` to ensure all assets are inlined and CSS is not split. Added `dist` directory to `.gitignore` to manage output files.